### PR TITLE
Adds `jira` wrapper API

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -217,7 +217,9 @@ attr-rgx=^_{0,2}[a-z][a-z0-9_]*$
 argument-rgx=^[a-z][a-z0-9_]*$
 
 # Regular expression matching correct class attribute names
-class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+# Anaconda Delta: Allow for `__` in class members, to prevent mangling of private class members
+#   See https://docs.python.org/3/tutorial/classes.html#private-variables for details
+class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*|__?[a-z][a-z0-9_]*)$
 
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=^[a-z][a-z0-9_]*$

--- a/.pytest.ini
+++ b/.pytest.ini
@@ -1,0 +1,6 @@
+# This surpresses deprecation `pytest` warnings. These crop up when dependencies release updates. Most of these are
+# not relevant and could be solved by pinning a package to an older version, if they do arise.
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning

--- a/Makefile
+++ b/Makefile
@@ -94,11 +94,11 @@ test:						## executes unit test cases
 	$(PYTHON3) -m pytest -n auto --capture=no anaconda_packaging_utils/tests/
 
 test-debug:		## runs test cases with debugging info enabled
-	$(PYTHON3) -m pytest -n auto -vv --capture=no tests/
+	$(PYTHON3) -m pytest -n auto -vv --capture=no anaconda_packaging_utils/tests/
 
 test-cov:					## checks test coverage requirements
 	$(PYTHON3) -m pytest -n auto --cov-config=.coveragerc --cov=anaconda_packaging_utils \
-		anaconda_packaging_utils/tests/ --cov-fail-under=75 --cov-report term-missing
+		anaconda_packaging_utils/tests/ --cov-fail-under=80 --cov-report term-missing
 
 lint:						## runs the linter against the project
 	pylint --rcfile=.pylintrc anaconda_packaging_utils

--- a/anaconda-packaging-utils-config-template.yaml
+++ b/anaconda-packaging-utils-config-template.yaml
@@ -1,10 +1,17 @@
 # This contains configuration values needed for the tools provided by
 # the `anaconda-packaging-utils` project.
 token:
+  # Used for the GitHubApi module
   # Generate a token, following the GitHub docs:
   #   https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token
   # TODO determine permissions
   github: TODO
+  # Used for the JiraApi module. Instructions can be found here:
+  #   https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
+  jira: TODO
+user_info:
+  # Work email address used for SSO apps
+  email: TODO
 local_path:
   # Full path to your local copy of the `aggregate` repository
   aggregate: TODO

--- a/anaconda_packaging_utils/api/_types.py
+++ b/anaconda_packaging_utils/api/_types.py
@@ -1,0 +1,21 @@
+"""
+File:           _types.py
+Description:    Contains types and classes used internally for the API modules.
+"""
+
+
+class BaseApiException(Exception):
+    """
+    Generic exception indicating an unrecoverable failure of this API.
+
+    This exception is meant to condense many possible failures into one generic error. The thinking is, if the calling
+    code runs into any API failure, there isn't much that can be done. So it is easier for the caller to handle one
+    exception than many exception types.
+    """
+
+    def __init__(self, message: str):
+        """
+        Constructs an API exception
+        :param message: String description of the issue encountered.
+        """
+        super().__init__(message if len(message) else "An unknown API issue was encountered.")

--- a/anaconda_packaging_utils/api/github_api.py
+++ b/anaconda_packaging_utils/api/github_api.py
@@ -14,6 +14,7 @@ from github import Github, Repository
 from percy.render.recipe import Recipe
 
 import anaconda_packaging_utils.cryptography.utils as crypto_utils
+from anaconda_packaging_utils.api._types import BaseApiException
 from anaconda_packaging_utils.storage import file_io
 from anaconda_packaging_utils.storage.config_data import ConfigData
 
@@ -26,21 +27,12 @@ ANACONDA_RECIPE_BASE: Final[str] = "AnacondaRecipes"
 REPO_AGGREGATE_PATH: Final[str] = f"{ANACONDA_RECIPE_BASE}/aggregate"
 
 
-class ApiException(Exception):
+class ApiException(BaseApiException):
     """
-    Generic exception indicating an unrecoverable failure of this API.
-
-    This exception is meant to condense many possible failures into one generic error. The thinking is, if the calling
-    code runs into any API failure, there isn't much that can be done. So it is easier for the caller to handle one
-    exception than many exception types.
+    Generic exception indicating an unrecoverable failure of this API. See the base class for more context.
     """
 
-    def __init__(self, message: str):
-        """
-        Constructs an API exception
-        :param message: String description of the issue encountered.
-        """
-        super().__init__(message if len(message) else "An unknown API issue was encountered.")
+    pass
 
 
 class GitHubApi:
@@ -62,7 +54,7 @@ class GitHubApi:
         Constructs a GitHubApi Instance
         :raises ApiException: If there was a failure to authenticate.
         """
-        if len(GitHubApi.__gh) == 0:
+        if not GitHubApi.__gh:
             try:
                 GitHubApi.__gh.append(Github(ConfigData()["token.github"]))
             except Exception as e:
@@ -145,7 +137,8 @@ class GitHubApi:
         log.info("Recipe for `%s` downloaded to: %s", package, tmp)
         return Recipe.from_file(tmp)
 
-    def get_github(self) -> Github:
+    @property
+    def github(self) -> Github:
         """
         Exposes an authenticated GitHub API instance directly to the caller, allowing for full use of the API.
         As this is a member function, successful construction of a `GitHubApi` instance must have occurred previously

--- a/anaconda_packaging_utils/api/jira_api.py
+++ b/anaconda_packaging_utils/api/jira_api.py
@@ -1,0 +1,80 @@
+"""
+File:           jira_api.py
+Description:    Wrapper library that provides tools for using the Python JIRA API. The primary purpose of this wrapper
+                is to simplify and standardize the authentication process.
+
+                JIRA API links:
+                  - Source: https://github.com/pycontribs/jira
+                  - Docs: https://jira.readthedocs.io/index.html#
+"""
+import logging
+from typing import Callable, Final
+
+from jira.client import JIRA
+
+from anaconda_packaging_utils.storage.config_data import ConfigData
+
+# Logging object for this module
+log = logging.getLogger(__name__)
+
+# Where our JIRA boards are hosted
+_JIRA_HOST_URL: Final[str] = "https://anaconda.atlassian.net/"
+
+
+class ApiException(Exception):
+    """
+    Generic exception indicating an unrecoverable failure of this API.
+
+    This exception is meant to condense many possible failures into one generic error. The thinking is, if the calling
+    code runs into any API failure, there isn't much that can be done. So it is easier for the caller to handle one
+    exception than many exception types.
+    """
+
+    def __init__(self, message: str):
+        """
+        Constructs an API exception
+        :param message: String description of the issue encountered.
+        """
+        super().__init__(message if len(message) else "An unknown API issue was encountered.")
+
+
+class JiraApi:
+    """
+    Singleton wrapper to the Python Jira project. This "ensures" that we only construct and authenticate the underlying
+    Jira object once.
+    """
+
+    # The Jira API is wrapped in a list as a cheesy way to work around an initialization problem. Defaulting to `None`
+    # or using an `Optional` causes the static analyzer to freak out on every use of the `_jira`, even if the static
+    # variable has to have been initialized by instance-method call time.
+    _jira: list[JIRA] = []
+
+    def __init__(self) -> None:
+        """
+        Constructs a JiraApi instance
+        :raises ApiException: If there was a failure to authenticate.
+        """
+        if len(JiraApi._jira) == 0:
+            data_store: Final[ConfigData] = ConfigData()
+            try:
+                JiraApi._jira.append(
+                    JIRA(
+                        _JIRA_HOST_URL,
+                        basic_auth=(data_store["user_info.email"], data_store["token.jira"]),
+                    )
+                )
+            except Exception as e:
+                raise ApiException("Failed to auth or connect to JIRA") from e
+
+    def access_jira(self, callback: Callable[[JIRA], None]) -> None:
+        """
+        Execute Jira commands via a callback. This ensures some amount of safety around our singleton design pattern
+        while also allowing the caller to full access of the API.
+        :param callback: Callback that provides access to the single Jira client instance
+        :raises ApiException: If the callback throws, it will re-wrap the exception into a generic `ApiException` for
+                              easier exception handling.
+        """
+        try:
+            callback(JiraApi._jira[0])
+        except Exception as e:
+            raise ApiException("`access_jira()` callback raised an exception") from e

--- a/anaconda_packaging_utils/api/pypi_api.py
+++ b/anaconda_packaging_utils/api/pypi_api.py
@@ -16,6 +16,7 @@ import requests
 from jsonschema import validate as schema_validate
 
 import anaconda_packaging_utils.cryptography.utils as crypto_utils
+from anaconda_packaging_utils.api._types import BaseApiException
 from anaconda_packaging_utils.types import JsonType, SchemaType
 
 # Logging object for this module
@@ -196,21 +197,12 @@ class PackageMetadata:
     releases: dict[str, VersionMetadata]  # version -> metadata
 
 
-class ApiException(Exception):
+class ApiException(BaseApiException):
     """
-    Generic exception indicating an unrecoverable failure of this API.
-
-    This exception is meant to condense many possible failures into one generic error. The thinking is, if the calling
-    code runs into any API failure, there isn't much that can be done. So it is easier for the caller to handle one
-    exception than many exception types.
+    Generic exception indicating an unrecoverable failure of this API. See the base class for more context.
     """
 
-    def __init__(self, message: str):
-        """
-        Constructs an API exception
-        :param message: String description of the issue encountered.
-        """
-        super().__init__(message if len(message) else "An unknown API issue was encountered.")
+    pass
 
 
 def _calc_package_metadata_url(package: str) -> str:

--- a/anaconda_packaging_utils/storage/config_data.py
+++ b/anaconda_packaging_utils/storage/config_data.py
@@ -37,13 +37,20 @@ def _generate_config_schema() -> SchemaType:
         "type": "object",
         "required": [
             "token",
+            "user_info",
             "local_path",
         ],
         "properties": {
+            # Tokens are generally not required as some developers may not need to use all of the APIs/tools that
+            # require tokens
             "token": {
                 "type": "object",
-                "required": ["github"],
-                "properties": {"github": {"type": "string"}},
+                "properties": {"github": {"type": "string"}, "jira": {"type": "string"}},
+            },
+            "user_info": {
+                "type": "object",
+                "required": ["email"],
+                "properties": {"email": {"type": "string"}},
             },
             "local_path": {
                 "type": "object",
@@ -108,7 +115,8 @@ class ConfigData:
 
     def __str__(self) -> str:
         """
-        Pretty-prints the configuration data key-value map as a string. Use only for debugging purposes.
+        Pretty-prints the configuration data key-value map as a string.
+        USE ONLY FOR DEBUGGING/TESTING PURPOSES; WE DO NOT WANT TO LOG KEYS AND TOKENS!
         :returns: Pretty-printed version of the key-value table.
         """
         with ConfigData._mutex:

--- a/anaconda_packaging_utils/tests/api/test_github_api.py
+++ b/anaconda_packaging_utils/tests/api/test_github_api.py
@@ -1,0 +1,24 @@
+"""
+File:           test_github_api.py
+Description:    Tests GitHub (wrapper) API library
+"""
+
+from unittest.mock import patch
+
+import pytest
+from github import Github
+
+from anaconda_packaging_utils.api import github_api
+
+
+def test_access_raises() -> None:
+    """
+    Ensures that we are capturing and re-throwing exceptions that occur in an API access callback.
+    """
+    with patch("anaconda_packaging_utils.api.github_api.Github"):
+
+        def _to_throw(j: Github) -> None:
+            raise ValueError()
+
+        with pytest.raises(github_api.ApiException):
+            github_api.GitHubApi().access_github(_to_throw)

--- a/anaconda_packaging_utils/tests/api/test_github_api.py
+++ b/anaconda_packaging_utils/tests/api/test_github_api.py
@@ -16,4 +16,4 @@ def test_get_github_smoke() -> None:
     Smoke test that ensures that we return an underlying constructed object.
     """
     with patch("anaconda_packaging_utils.api.github_api.Github"):
-        assert isinstance(github_api.GitHubApi().get_github(), object)
+        assert isinstance(github_api.GitHubApi().github, object)

--- a/anaconda_packaging_utils/tests/api/test_github_api.py
+++ b/anaconda_packaging_utils/tests/api/test_github_api.py
@@ -5,20 +5,13 @@ Description:    Tests GitHub (wrapper) API library
 
 from unittest.mock import patch
 
-import pytest
-from github import Github
-
 from anaconda_packaging_utils.api import github_api
 
 
-def test_access_raises() -> None:
+def test_get_github_smoke() -> None:
     """
-    Ensures that we are capturing and re-throwing exceptions that occur in an API access callback.
+    Smoke test that ensures that we return an underlying constructed object.
     """
+    # TODO: Improve this test, the mocker masks what we are attempting to check for
     with patch("anaconda_packaging_utils.api.github_api.Github"):
-
-        def _to_throw(j: Github) -> None:
-            raise ValueError()
-
-        with pytest.raises(github_api.ApiException):
-            github_api.GitHubApi().access_github(_to_throw)
+        assert isinstance(github_api.GitHubApi().get_github(), object)

--- a/anaconda_packaging_utils/tests/api/test_github_api.py
+++ b/anaconda_packaging_utils/tests/api/test_github_api.py
@@ -5,13 +5,15 @@ Description:    Tests GitHub (wrapper) API library
 
 from unittest.mock import patch
 
+import pytest
+
 from anaconda_packaging_utils.api import github_api
 
 
+@pytest.mark.skip(reason="TODO: Improve this test and ensure the mocker suppresses network calls")
 def test_get_github_smoke() -> None:
     """
     Smoke test that ensures that we return an underlying constructed object.
     """
-    # TODO: Improve this test, the mocker masks what we are attempting to check for
     with patch("anaconda_packaging_utils.api.github_api.Github"):
         assert isinstance(github_api.GitHubApi().get_github(), object)

--- a/anaconda_packaging_utils/tests/api/test_jira_api.py
+++ b/anaconda_packaging_utils/tests/api/test_jira_api.py
@@ -5,20 +5,13 @@ Description:    Tests JIRA (wrapper) API library
 
 from unittest.mock import patch
 
-import pytest
-from jira.client import JIRA
-
 from anaconda_packaging_utils.api import jira_api
 
 
-def test_access_raises() -> None:
+def test_get_jira_smoke() -> None:
     """
-    Ensures that we are capturing and re-throwing exceptions that occur in an API access callback.
+    Smoke test that ensures that we return an underlying constructed object.
     """
+    # TODO: Improve this test, the mocker masks what we are attempting to check for
     with patch("anaconda_packaging_utils.api.jira_api.JIRA"):
-
-        def _to_throw(j: JIRA) -> None:
-            raise ValueError()
-
-        with pytest.raises(jira_api.ApiException):
-            jira_api.JiraApi().access_jira(_to_throw)
+        assert isinstance(jira_api.JiraApi().get_jira(), object)

--- a/anaconda_packaging_utils/tests/api/test_jira_api.py
+++ b/anaconda_packaging_utils/tests/api/test_jira_api.py
@@ -5,13 +5,15 @@ Description:    Tests JIRA (wrapper) API library
 
 from unittest.mock import patch
 
+import pytest
+
 from anaconda_packaging_utils.api import jira_api
 
 
+@pytest.mark.skip(reason="TODO: Improve this test and ensure the mocker suppresses network calls")
 def test_get_jira_smoke() -> None:
     """
     Smoke test that ensures that we return an underlying constructed object.
     """
-    # TODO: Improve this test, the mocker masks what we are attempting to check for
     with patch("anaconda_packaging_utils.api.jira_api.JIRA"):
         assert isinstance(jira_api.JiraApi().get_jira(), object)

--- a/anaconda_packaging_utils/tests/api/test_jira_api.py
+++ b/anaconda_packaging_utils/tests/api/test_jira_api.py
@@ -16,4 +16,4 @@ def test_get_jira_smoke() -> None:
     Smoke test that ensures that we return an underlying constructed object.
     """
     with patch("anaconda_packaging_utils.api.jira_api.JIRA"):
-        assert isinstance(jira_api.JiraApi().get_jira(), object)
+        assert isinstance(jira_api.JiraApi().jira, object)

--- a/anaconda_packaging_utils/tests/api/test_jira_api.py
+++ b/anaconda_packaging_utils/tests/api/test_jira_api.py
@@ -1,0 +1,24 @@
+"""
+File:           test_jira_api.py
+Description:    Tests JIRA (wrapper) API library
+"""
+
+from unittest.mock import patch
+
+import pytest
+from jira.client import JIRA
+
+from anaconda_packaging_utils.api import jira_api
+
+
+def test_access_raises() -> None:
+    """
+    Ensures that we are capturing and re-throwing exceptions that occur in an API access callback.
+    """
+    with patch("anaconda_packaging_utils.api.jira_api.JIRA"):
+
+        def _to_throw(j: JIRA) -> None:
+            raise ValueError()
+
+        with pytest.raises(jira_api.ApiException):
+            jira_api.JiraApi().access_jira(_to_throw)

--- a/anaconda_packaging_utils/tests/storage/test_config_data.py
+++ b/anaconda_packaging_utils/tests/storage/test_config_data.py
@@ -16,6 +16,8 @@ VALID_SCHEMA_TO_STR: Final[
     str
 ] = """{
   "token.github": "aec070645fe53ee3b3763059376134f058cc",
+  "token.jira": "eac070645fe53ee3b3763059376134f058cc",
+  "user_info.email": "foobar@anaconda.com",
   "local_path.aggregate": "/home/fakeuser/work/aggregate"
 }"""
 
@@ -118,6 +120,8 @@ def test_caching() -> None:
     file_data = """
     token:
       github: aec070645fe53ee3b3763059376134f058cc
+    user_info:
+      email: foobar@anaconda.com
     local_path:
       aggregate: /home/fakeuser/work/aggregate
     """

--- a/anaconda_packaging_utils/tests/test_aux_files/config_files/valid_schema.yaml
+++ b/anaconda_packaging_utils/tests/test_aux_files/config_files/valid_schema.yaml
@@ -1,4 +1,7 @@
 token:
   github: aec070645fe53ee3b3763059376134f058cc
+  jira: eac070645fe53ee3b3763059376134f058cc
+user_info:
+  email: foobar@anaconda.com
 local_path:
   aggregate: /home/fakeuser/work/aggregate

--- a/anaconda_packaging_utils/tests/testing_utils.py
+++ b/anaconda_packaging_utils/tests/testing_utils.py
@@ -5,6 +5,9 @@ Description:    Contains constants and other utilities used throughout the unit 
 import json
 from pathlib import Path
 
+import pytest
+
+from anaconda_packaging_utils.storage.config_data import ConfigData
 from anaconda_packaging_utils.types import JsonType
 
 # Path to supplementary files used in test cases
@@ -23,3 +26,16 @@ def load_json_file(file: Path | str) -> JsonType:
     with open(Path(file), "r", encoding="utf-8") as f:
         j: JsonType = json.load(f)
         return j
+
+
+@pytest.fixture()
+def config_data() -> ConfigData:
+    """
+    Text fixture that generates a valid `ConfigData` instance with mocked test information.
+
+    As this class follows a singleton pattern, the existence of this fixture is enough to bootstrap-initialize an
+    instance to contain information to pass. The API modules tend to rely on this.
+
+    :return: ConfigData instance that can be used for tests
+    """
+    return ConfigData(f"{TEST_FILES_PATH}/config_files/valid_schema.yaml")

--- a/environment.yaml
+++ b/environment.yaml
@@ -14,8 +14,9 @@ dependencies:
   # Python libraries
   - jsonschema
   - types-jsonschema
-  - distro-tooling::percy>=0.1.3
+  - distro-tooling::percy >=0.1.3
   - PyGithub
+  - jira >=3.6.0
   - pyyaml
   - types-pyyaml
   - requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,14 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
+  "jsonschema",
+  "types-jsonschema",
+  "PyGithub",
+  "jira",
+  "pyyaml",
+  "types-pyyaml",
   "requests",
+  "types-requests",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- This API manages the API token in the "standard" packaging utils way
  - This class follows a singleton design, like the GitHub API wrapper
  - Access to the underlying object is restricted through use of a callback. This is intended to help with some future thread-safety goals and to reduce the number of constructions and authorization requests.
- Backports some of the new ideas to the GitHub API wrapper
- Adds unit tests. The GitHub and Jira APIs now have some amount of mocked-out unit testing to back them